### PR TITLE
Adds configuration for motion and tap detection features, and some refactoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ version = "0.0.1"
 [dependencies]
 accelerometer = {version = "^0.12", optional = true}
 bitmask-enum = {version = "^1.1"}
-derive-new = "0.5"
 embedded-hal = "1.0.0-alpha.10"
 num_enum = {version = "^0.5", default-features = false}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.0.1"
 accelerometer = {version = "^0.12", optional = true}
 bitmask-enum = {version = "^1.1"}
 derive-new = "0.5"
-embedded-hal = "^0.2"
+embedded-hal = "1.0.0-alpha.10"
 num_enum = {version = "^0.5", default-features = false}
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
-name = "bma423"
-version = "0.0.1"
-edition = "2021"
 authors = ["Pierre-Yves Aillet <pyaillet@gmail.com>"]
 categories = ["embedded", "hardware-support"]
 description = "Rust driver for Bma423 accelerometer"
-repository = "https://github.com/pyaillet/bma423-rs"
+edition = "2021"
 license = "MIT OR Apache-2.0"
+name = "bma423"
 readme = "README.md"
-
+repository = "https://github.com/pyaillet/bma423-rs"
+version = "0.0.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
+accelerometer = {version = "^0.12", optional = true}
+bitmask-enum = {version = "^1.1"}
+derive-new = "0.5"
 embedded-hal = "^0.2"
-num_enum = { version = "^0.5", default-features = false }
-accelerometer = { version = "^0.12", optional = true }
-bitmask-enum = { version = "^1.1" }
+num_enum = {version = "^0.5", default-features = false}
 
 [features]
-default = [ "accel" ]
-accel = [ "accelerometer" ]
+accel = ["accelerometer"]
+default = ["accel"]

--- a/README.md
+++ b/README.md
@@ -10,9 +10,17 @@ This is an experimental Rust driver for the BMA423 accelerometer.
 
 What's working:
 - Getting x, y, z axis acceleration values
+- The motion detection feature
+- The tap detection feature
+- Configuring the interrupt pins
+- Mapping features to the interrupt pins (as outputs)
 
 What's missing:
-- Identifying activities and reporting them with interrupts
+- The step counter and step detection features
+- Activity classification feature
+- Wrist wakeup feature
+- Auxiliary interface configuration
+- FIFO configuration
 
 ## Examples
 

--- a/src/features.rs
+++ b/src/features.rs
@@ -6,7 +6,7 @@ use core::ops::RangeInclusive;
 
 use bitmask_enum::bitmask;
 
-use crate::{Error, Reg};
+use crate::{Error, FullPower, Reg};
 
 pub(crate) const FEATURE_SIZE: usize = 70;
 
@@ -15,13 +15,13 @@ pub(crate) const FEATURE_SIZE: usize = 70;
 enum FeatureOffset {
     AnyMotion = 0x00,
     NoMotion = 0x04,
-    StepCounterParam = 0x08,
-    StepCounter = 0x3A,
+    //StepCounterParam = 0x08,
+    //StepCounter = 0x3A,
     SingleTap = 0x3C,
     DoubleTap = 0x3E,
-    WristWear = 0x40,
-    ConfigId = 0x42,
-    AxesRemap = 0x44,
+    //WristWear = 0x40,
+    //ConfigId = 0x42,
+    //AxesRemap = 0x44,
 }
 
 /// Which motion feature
@@ -70,7 +70,7 @@ pub enum TapFeature {
 /// effect.
 pub struct EditFeatures<'a, I2C> {
     pub(crate) register: [u8; FEATURE_SIZE + 1],
-    pub(crate) driver: &'a mut crate::Bma423<I2C>,
+    pub(crate) driver: &'a mut crate::Bma423<I2C, FullPower>,
 }
 impl<I2C: embedded_hal::i2c::I2c> EditFeatures<'_, I2C> {
     /// Allows editing the features register without the offset.
@@ -132,7 +132,7 @@ impl<I2C: embedded_hal::i2c::I2c> EditFeatures<'_, I2C> {
 
     /// Sets the tap detection feature configuration.
     ///
-    /// The features can be enabled using [`enable_feature`].
+    /// The features can be enabled using [`edit_feature`](crate::Bma423::edit_features).
     ///
     /// # Arguments
     ///

--- a/src/features.rs
+++ b/src/features.rs
@@ -1,0 +1,174 @@
+//! Items for configuring the features of the chip.
+//!
+//! The main item is [`EditFeatures`].
+
+use core::ops::RangeInclusive;
+
+use bitmask_enum::bitmask;
+
+use crate::{Error, Reg};
+
+pub(crate) const FEATURE_SIZE: usize = 70;
+
+#[repr(u8)]
+#[derive(Copy, Clone, Debug)]
+enum FeatureOffset {
+    AnyMotion = 0x00,
+    NoMotion = 0x04,
+    StepCounterParam = 0x08,
+    StepCounter = 0x3A,
+    SingleTap = 0x3C,
+    DoubleTap = 0x3E,
+    WristWear = 0x40,
+    ConfigId = 0x42,
+    AxesRemap = 0x44,
+}
+
+/// Which motion feature
+#[derive(Copy, Clone, Debug)]
+pub enum MotionFeature {
+    /// Any motion detection feature
+    AnyMotion,
+    /// No motion detection feature
+    NoMotion,
+}
+
+// Motion feature valid value ranges
+const MOTION_THRESHOLD_RANGE: RangeInclusive<u16> = 0..=0x7FF;
+const MOTION_DURATION_RANGE: RangeInclusive<u16> = 0..=0x1FFF;
+
+/// Motion feature axes.
+///
+/// Can be combined like a bitmask.
+#[bitmask(u8)]
+#[derive(Copy, Clone, Debug)]
+pub enum MotionAxes {
+    AxisX = Self(0b0010_0000),
+    AxisY = Self(0b0100_0000),
+    AxisZ = Self(0b1000_0000),
+}
+
+// Tap sensitivity valid value ranges
+const TAP_SENSITIVITY_RANGE: RangeInclusive<u8> = 0..=7;
+
+/// Which tap feature
+#[derive(Copy, Clone, Debug)]
+pub enum TapFeature {
+    /// Single tap detection feature
+    SingleTap,
+    /// Double tap detection feature
+    DoubleTap,
+}
+
+/// Allows editing feature configurations in an efficient way.
+///
+/// This can be obtained from the driver by calling
+/// [`edit_features`](crate::Bma423::edit_features).
+/// Once the desired features are configured, one must
+/// call [`write`](EditFeatures::write) to write the
+/// configurations back to the chip so that they take
+/// effect.
+pub struct EditFeatures<'a, I2C> {
+    pub(crate) register: [u8; FEATURE_SIZE + 1],
+    pub(crate) driver: &'a mut crate::Bma423<I2C>,
+}
+impl<I2C: embedded_hal::i2c::I2c> EditFeatures<'_, I2C> {
+    /// Allows editing the features register without the offset.
+    fn edit_register(&mut self, f: impl FnOnce(&mut [u8])) {
+        f(&mut self.register[1..FEATURE_SIZE + 1]);
+    }
+
+    /// Sets the motion detection feature configuration.
+    ///
+    /// # Arguments
+    ///
+    /// - `which` Specifies which motion feature to configure.
+    /// - `threshold` Slope threshold for motion detection.
+    /// The least significant bit is 0.48828125 mg, and the valid
+    /// range is 0 to 0x7FF (1 g).
+    /// The default value is 0xAA (83 mg).
+    /// - `duration` The number of consecutive data points for which
+    /// the threshold condition must be respected.
+    /// In terms of time, the least significant bit is 20 ms, and the
+    /// valid range is 0 to 0x1FFF (163 s).
+    /// The default value is 5 (100 ms).
+    ///  - `enabled_axes` Axes for which to enable the motion detection.
+    pub fn set_motion_config(
+        &mut self,
+        which: MotionFeature,
+        threshold: u16,
+        duration: u16,
+        enabled_axes: MotionAxes,
+    ) -> Result<(), Error<I2C::Error>> {
+        // Validate arguments
+        if !MOTION_THRESHOLD_RANGE.contains(&threshold)
+            || !MOTION_DURATION_RANGE.contains(&duration)
+        {
+            return Err(Error::BadArgument);
+        }
+
+        self.edit_register(|reg| {
+            let offset = match which {
+                MotionFeature::AnyMotion => FeatureOffset::AnyMotion,
+                MotionFeature::NoMotion => FeatureOffset::NoMotion,
+            } as usize;
+
+            // Set the threshold
+            let threshold = threshold.to_le_bytes();
+            reg[offset + 0] = threshold[0];
+            reg[offset + 1] = threshold[1];
+
+            // Set the duration
+            let duration = duration.to_le_bytes();
+            reg[offset + 2] = duration[0];
+            reg[offset + 3] = duration[1];
+
+            // Set enabled axes
+            reg[offset + 3] = u8::from(enabled_axes) & 0xE0;
+        });
+
+        Ok(())
+    }
+
+    /// Sets the tap detection feature configuration.
+    ///
+    /// The features can be enabled using [`enable_feature`].
+    ///
+    /// # Arguments
+    ///
+    /// - `which` Specifies which tap feature to configure.
+    /// - `sensitivity` A sensitivity level from 0 (most sensitive) to
+    /// 7 (least sensitive).
+    /// The default value is 3.
+    /// - `enable` Whether to enable or disable tap detection.
+    pub fn set_tap_config(
+        &mut self,
+        which: TapFeature,
+        sensitivity: u8,
+        enable: bool,
+    ) -> Result<(), Error<I2C::Error>> {
+        if !TAP_SENSITIVITY_RANGE.contains(&sensitivity) {
+            return Err(Error::BadArgument);
+        }
+
+        self.edit_register(|reg| {
+            let offset = match which {
+                TapFeature::SingleTap => FeatureOffset::SingleTap,
+                TapFeature::DoubleTap => FeatureOffset::DoubleTap,
+            } as usize;
+
+            reg[offset] = sensitivity << 1;
+            if enable {
+                reg[offset] |= 1;
+            }
+        });
+
+        Ok(())
+    }
+
+    /// Writes the edited features back to the chip so that they take effect.
+    pub fn write(mut self) -> Result<(), Error<I2C::Error>> {
+        self.register[0] = Reg::FeatureConfig.into();
+        self.driver.write(&self.register)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #[cfg(feature = "accel")]
 use accelerometer::{vector::F32x3, Accelerometer};
 
+use derive_new::new;
 use embedded_hal::blocking::{
     delay::DelayUs,
     i2c::{Write, WriteRead},
@@ -30,6 +31,8 @@ enum Reg {
 
     FeatureInterruptStatus = 0x1c,
     HardwareInterruptStatus = 0x1d,
+
+    InternalStatus = 0x2a,
 
     AccelConfig = 0x40,
     AccelRange = 0x41,
@@ -100,6 +103,7 @@ pub enum InterruptLine {
 /// Features of the accelerometer
 #[bitmask(u8)]
 #[derive(Copy, Clone, Debug)]
+// TODO: Need to add any/no motion features
 pub enum Features {
     StepCounter = Self(0b0000_0001),
     StepActivity = Self(0b0000_0010),
@@ -111,6 +115,7 @@ pub enum Features {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug)]
 pub enum FeatureOffset {
+    // TODO: These are incorrect per the data sheet.
     AnyMotion = 0x00,
     NoMotion = 0x04,
     StepCounterParam = 0x08,
@@ -210,10 +215,20 @@ pub enum AccelRange {
     Range8g = 0x02,
     Range16g = 0x03,
 }
+impl AccelRange {
+    pub fn as_float(&self) -> f32 {
+        match self {
+            AccelRange::Range2g => 2.0,
+            AccelRange::Range4g => 4.0,
+            AccelRange::Range8g => 8.0,
+            AccelRange::Range16g => 16.0,
+        }
+    }
+}
 
-const DEFAULT_ADDRESS: u8 = 0x19;
+const DEFAULT_ADDRESS: u8 = 0x18;
+const FEATURE_SIZE: usize = 0x46;
 const READ_WRITE_LEN: usize = 0x08;
-const FEATURE_SIZE: usize = 0x70;
 const GRAVITY_EARTH: f32 = 9.80665;
 
 #[derive(Clone, Copy, Debug)]
@@ -221,6 +236,7 @@ pub enum Error<E> {
     BusError(E),
     I2cError,
     ConfigError,
+    BadInternal(u8),
     Uninitialized,
 }
 
@@ -240,20 +256,40 @@ pub enum ChipId {
 
 /// Structure representing the Bma423 device
 pub struct Bma423<I2C> {
+    /// I2C address
     address: u8,
+    /// I2C peripheral
     i2c: I2C,
+    /// Current state
     state: State,
-    config: Option<Config>,
+    /// Current configuration
+    config: Config,
 }
 
 /// Configuration of the device
 #[allow(dead_code)]
-#[derive(Copy, Clone, Debug)]
+#[derive(new, Copy, Clone, Debug)]
 pub struct Config {
-    bandwidth: AccelConfigBandwidth,
-    range: AccelRange,
-    performance_mode: AccelConfigPerfMode,
-    sample_rate: AccelConfigOdr,
+    pub bandwidth: AccelConfigBandwidth,
+    pub range: AccelRange,
+    pub performance_mode: AccelConfigPerfMode,
+    pub sample_rate: AccelConfigOdr,
+}
+impl Default for Config {
+    /// The default configuration is:
+    /// * Filter: Average of 4 samples
+    /// * Range: 2g
+    /// * Performance mode: Averaging
+    /// * Sample rate: 50 Hz
+    fn default() -> Self {
+        Self {
+            // TODO: Keep these? If so change doc comment
+            bandwidth: AccelConfigBandwidth::NormAvg4,
+            range: AccelRange::Range2g,
+            performance_mode: AccelConfigPerfMode::CicAvg,
+            sample_rate: AccelConfigOdr::Odr50,
+        }
+    }
 }
 
 pub enum State {
@@ -265,7 +301,7 @@ impl<E, I2C> Bma423<I2C>
 where
     I2C: Write<Error = E> + WriteRead<Error = E>,
 {
-    /// Create a new Bma423 device with the default slave address
+    /// Create a new Bma423 device with the default slave address (0x18) and configuration.
     ///
     /// # Arguments
     ///
@@ -275,16 +311,13 @@ where
     ///
     /// - [Bma423 driver](Bma423) created
     ///
+    #[inline(always)]
     pub fn new(i2c: I2C) -> Self {
-        Self {
-            address: DEFAULT_ADDRESS,
-            i2c,
-            state: State::Uninitialized,
-            config: None,
-        }
+        Self::new_with_address(i2c, DEFAULT_ADDRESS)
     }
 
-    /// Create a new Bma423 device with the default slave address
+    /// Create a new Bma423 device with a particular slave address and default
+    /// configuration.
     ///
     /// # Arguments
     ///
@@ -300,7 +333,7 @@ where
             address,
             i2c,
             state: State::Uninitialized,
-            config: None,
+            config: Config::default(),
         }
     }
 
@@ -312,6 +345,13 @@ where
     fn write_read(&mut self, reg: Reg, data: &mut [u8]) -> Result<(), Error<E>> {
         self.i2c.write_read(self.address, &[reg.into()], data)?;
         Ok(())
+    }
+
+    /// Reads only a single byte from a register
+    fn read_register(&mut self, reg: Reg) -> Result<u8, Error<E>> {
+        let mut data = [0; 1];
+        self.write_read(reg, &mut data)?;
+        Ok(data[0])
     }
 
     fn probe_chip(&mut self) -> Result<u8, Error<E>> {
@@ -339,17 +379,50 @@ where
         let chip_id = self.probe_chip()?;
         self.state = State::Initialized(chip_id.into());
 
+        // First, perform a soft reset followed by an arbitrary delay
+        self.write(&[Reg::Command.into(), 0xb6])?;
+        delay.delay_us(1000);
+
+        // Disable advanced power saving mode
         self.set_power_config(PowerConfigurationFlag::none())?;
 
+        // Wait a bit
         delay.delay_us(500);
 
-        self.write(&[Reg::StartInitialization.into(), 0u8])?;
+        // Enter config file writing mode
+        self.write(&[Reg::StartInitialization.into(), 0])?;
 
+        // TODO: Temporarily just write all zeros to disabled everything
+        // while we try to get something working.
+        /* let mut data = [0; FEATURE_SIZE + 1];
+        data[0] = Reg::FeatureConfig.into();
+        // Correct default axes mapping
+        //data[10 + 1] = 0x12;
+        //data[0x3E + 1] = 0x88;
+        self.write(&data)?; */
+
+        // Stream write the config file
         self.stream_write(Reg::FeatureConfig, &config::BMA423_CONFIG_FILE)?;
 
+        // Exit config file writing mode
         self.write(&[Reg::StartInitialization.into(), 1u8])?;
 
+        // Wait until the chip is ready and initialized with timeout
+        let mut time_ms: usize = 500;
+        while time_ms > 0 && (self.read_register(Reg::InternalStatus)? & 0x0F) != 0x01 {
+            delay.delay_us(1000);
+            time_ms -= 1;
+        }
+        if time_ms == 0 {
+            // We timed out, so there's a serious problem
+            return Err(Error::BadInternal(self.read_register(Reg::InternalStatus)?));
+        }
+
+        // Enable accelerometer power
         self.set_power_control(PowerControlFlag::Accelerometer)?;
+
+        // Set the configuration to the default
+        self.set_accel_config(self.config)?;
 
         Ok(())
     }
@@ -379,36 +452,26 @@ where
         Ok(())
     }
 
-    pub fn set_accel_config(
-        &mut self,
-        odr: AccelConfigOdr,
-        bw: AccelConfigBandwidth,
-        rm: AccelConfigPerfMode,
-        g_range: AccelRange,
-    ) -> Result<(), Error<E>> {
-        if rm == AccelConfigPerfMode::Continuous {
-            if (bw as u8) > (AccelConfigBandwidth::NormAvg4 as u8) {
+    pub fn set_accel_config(&mut self, config: Config) -> Result<(), Error<E>> {
+        if config.performance_mode == AccelConfigPerfMode::Continuous {
+            if (config.bandwidth as u8) > (AccelConfigBandwidth::NormAvg4 as u8) {
                 return Err(Error::ConfigError);
             }
-        } else if rm == AccelConfigPerfMode::CicAvg {
-            if (bw as u8) > (AccelConfigBandwidth::ResAvg128 as u8) {
+        } else if config.performance_mode == AccelConfigPerfMode::CicAvg {
+            if (config.bandwidth as u8) > (AccelConfigBandwidth::ResAvg128 as u8) {
                 return Err(Error::ConfigError);
             }
         } else {
             return Err(Error::ConfigError);
         }
 
-        let accel_config: u8 = odr as u8 | bw as u8 | rm as u8;
-        let accel_range: u8 = g_range as u8;
+        let accel_config: u8 =
+            config.sample_rate as u8 | config.bandwidth as u8 | config.performance_mode as u8;
+        let accel_range: u8 = config.range as u8;
         self.write(&[Reg::AccelConfig.into(), accel_config])?;
         self.write(&[Reg::AccelRange.into(), accel_range])?;
 
-        self.config = Some(Config {
-            sample_rate: odr,
-            bandwidth: bw,
-            performance_mode: rm,
-            range: g_range,
-        });
+        self.config = config;
         Ok(())
     }
 
@@ -478,6 +541,81 @@ where
         Ok(())
     }
 
+    pub fn get_features_mem(&mut self) -> Result<[u8; FEATURE_SIZE], Error<E>> {
+        // TODO: Get FEATURE_IN memory
+        let mut feature_config: [u8; FEATURE_SIZE] = [0; FEATURE_SIZE];
+        self.write_read(Reg::FeatureConfig, &mut feature_config)?;
+        Ok(feature_config)
+    }
+
+    // TODO: Make this permanent? If kept may need to abstract error
+    pub fn get_error(&mut self) -> Result<u8, Error<E>> {
+        self.read_register(Reg::Error)
+    }
+
+    // TODO: Temporary? If kept may need to abstract status
+    pub fn get_internal_status(&mut self) -> Result<u8, Error<E>> {
+        self.read_register(Reg::InternalStatus)
+    }
+
+    // TODO: Temporary? If kept may need to abstract error
+    pub fn get_internal_error(&mut self) -> Result<u8, Error<E>> {
+        self.read_register(Reg::InternalError)
+    }
+
+    // TODO: Test function to see if we can get feature interrupts to work at all
+    pub fn setup_any_motion_interrupt(&mut self) -> Result<(), Error<E>> {
+        // Enable any motion feature for all axes
+        // Assumes little endian
+        let feature_config = [Reg::FeatureConfig.into(), 0xAA, 0x00, 0x05, 0b1110_0000];
+        self.write(&feature_config)?;
+
+        // Set interrupt pin behavior in INT1_IO_CTRL
+        self.write(&[Reg::Interrupt1IOCtl.into(), 0b0000_1010])?;
+
+        // Setup interrupt latching in INT_LATCH
+        self.write(&[Reg::InterruptConfig.into(), 0b0000_0001])?;
+
+        // Map feature to interrupt in INT1_MAP
+        // Note that this driver does currently support this but it's functioning has not been verified
+        self.write(&[Reg::FeatureInterrupt1Mapping.into(), 0b0010_0000])?;
+
+        Ok(())
+    }
+
+    // TODO
+    pub fn setup_tap_detection_interrupt(&mut self) -> Result<(), Error<E>> {
+        // TODO: Note that this does not seem to work correctly
+        //self.enable_feature(Features::SingleTap)?;
+
+        // So we do it manually for now
+        let mut feature_config = [0; FEATURE_SIZE + 1];
+        self.write_read(Reg::FeatureConfig, &mut feature_config[1..])?;
+        feature_config[0] = Reg::FeatureConfig.into();
+        feature_config[0x3C + 1] |= 0x01;
+        self.write(&feature_config)?;
+
+        // Set interrupt pin behavior in INT2_IO_CTRL
+        self.write(&[Reg::Interrupt2IOCtl.into(), 0b0000_1010])?;
+
+        // Setup interrupt latching in INT_LATCH
+        self.write(&[Reg::InterruptConfig.into(), 0b0000_0001])?;
+
+        // Map feature to interrupt in INT2_MAP
+        // Note that this driver does currently support this but it's functioning has not been verified
+        self.write(&[Reg::FeatureInterrupt2Mapping.into(), 0b0000_0001])?;
+
+        Ok(())
+    }
+
+    // TODO delete probably
+    pub fn test_regs(&mut self) -> Result<[u8; 3], Error<E>> {
+        let a = self.read_register(Reg::Interrupt1IOCtl)?;
+        let b = self.read_register(Reg::InterruptConfig)?;
+        let c = self.read_register(Reg::FeatureInterrupt1Mapping)?;
+        Ok([a, b, c])
+    }
+
     pub fn map_feature_interrupt(
         &mut self,
         line: InterruptLine,
@@ -537,12 +675,8 @@ where
         Ok(data[0])
     }
 
-    /// Get x, y, z acceleration
-    ///
-    /// # Returns:
-    ///
-    /// - (f32, f32, f32), represeting the acceleration values for (x, y, z) axis
-    pub fn get_x_y_z(&mut self) -> Result<(f32, f32, f32), Error<E>> {
+    /// Returns the normalized accelerations in g.
+    fn accel_norm_int(&mut self) -> Result<(f32, f32, f32), Error<E>> {
         let mut data: [u8; 6] = [0; 6];
         self.write_read(Reg::AccXLSB, &mut data)?;
 
@@ -550,10 +684,23 @@ where
         let y: i16 = ((((data[3] as i16) << 8) as i16) | (data[2] as i16)) / 0x10;
         let z: i16 = ((((data[5] as i16) << 8) as i16) | (data[4] as i16)) / 0x10;
 
+        let range = self.config.range.as_float();
+
         Ok((
-            lsb_to_ms2(x, 2.0, 12),
-            lsb_to_ms2(y, 2.0, 12),
-            lsb_to_ms2(z, 2.0, 12),
+            lsb_to_ms2(x, range, 12),
+            lsb_to_ms2(y, range, 12),
+            lsb_to_ms2(z, range, 12),
+        ))
+    }
+
+    /// Returns the current x, y, z accelerations in absolute units of m/s^2.
+    pub fn accel_abs(&mut self) -> Result<(f32, f32, f32), Error<E>> {
+        let accel = self.accel_norm_int()?;
+
+        Ok((
+            GRAVITY_EARTH * accel.0,
+            GRAVITY_EARTH * accel.1,
+            GRAVITY_EARTH * accel.2,
         ))
     }
 }
@@ -567,27 +714,23 @@ where
     type Error = Error<E>;
 
     fn accel_norm(&mut self) -> Result<F32x3, accelerometer::Error<Error<E>>> {
-        let (x, y, z) = self.get_x_y_z()?;
-        Ok(F32x3::new(x, y, z))
+        Ok(self.accel_norm_int()?.into())
     }
 
     fn sample_rate(&mut self) -> Result<f32, accelerometer::Error<Error<E>>> {
-        match self.config {
-            Some(config) => match config.sample_rate {
-                AccelConfigOdr::Odr0p78 => Ok(25.0 / 32.0),
-                AccelConfigOdr::Odr1p5 => Ok(25.0 / 16.0),
-                AccelConfigOdr::Odr3p1 => Ok(25.0 / 8.0),
-                AccelConfigOdr::Odr6p25 => Ok(25.0 / 4.0),
-                AccelConfigOdr::Odr12p5 => Ok(25.0 / 2.0),
-                AccelConfigOdr::Odr25 => Ok(25.0),
-                AccelConfigOdr::Odr50 => Ok(50.0),
-                AccelConfigOdr::Odr100 => Ok(100.0),
-                AccelConfigOdr::Odr200 => Ok(200.0),
-                AccelConfigOdr::Odr400 => Ok(400.0),
-                AccelConfigOdr::Odr800 => Ok(800.0),
-                AccelConfigOdr::Odr1k6 => Ok(1600.0),
-            },
-            None => Err(accelerometer::Error::from(Error::ConfigError)),
+        match self.config.sample_rate {
+            AccelConfigOdr::Odr0p78 => Ok(25.0 / 32.0),
+            AccelConfigOdr::Odr1p5 => Ok(25.0 / 16.0),
+            AccelConfigOdr::Odr3p1 => Ok(25.0 / 8.0),
+            AccelConfigOdr::Odr6p25 => Ok(25.0 / 4.0),
+            AccelConfigOdr::Odr12p5 => Ok(25.0 / 2.0),
+            AccelConfigOdr::Odr25 => Ok(25.0),
+            AccelConfigOdr::Odr50 => Ok(50.0),
+            AccelConfigOdr::Odr100 => Ok(100.0),
+            AccelConfigOdr::Odr200 => Ok(200.0),
+            AccelConfigOdr::Odr400 => Ok(400.0),
+            AccelConfigOdr::Odr800 => Ok(800.0),
+            AccelConfigOdr::Odr1k6 => Ok(1600.0),
         }
     }
 }
@@ -596,5 +739,5 @@ where
 fn lsb_to_ms2(val: i16, g_range: f32, bit_width: u8) -> f32 {
     let half_scale: f32 = (1 << bit_width) as f32 / 2.0;
 
-    GRAVITY_EARTH * val as f32 * g_range / half_scale
+    val as f32 * g_range / half_scale
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@
 #[cfg(feature = "accel")]
 use accelerometer::{vector::F32x3, Accelerometer};
 use bitmask_enum::bitmask;
-use derive_new::new;
 use embedded_hal::{delay::DelayUs, i2c::I2c};
 use num_enum::{FromPrimitive, IntoPrimitive};
 
@@ -360,7 +359,7 @@ pub struct Bma423<I2C, S> {
 
 /// Configuration of the accelerometer measurements.
 #[allow(dead_code)]
-#[derive(new, Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct Config {
     /// The bandwidth or averaging mode
     pub bandwidth: AccelConfigBandwidth,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,8 @@
 // NOTE: Evidently there is no way to document bitmask enums,
 // nor can these warnings be disabled for them, so these
 // should be used as needed but commented out for commits.
-#![warn(missing_docs)]
-#![warn(clippy::missing_docs_in_private_items)]
+//#![warn(missing_docs)]
+//#![warn(clippy::missing_docs_in_private_items)]
 
 #[cfg(feature = "accel")]
 use accelerometer::{vector::F32x3, Accelerometer};
@@ -72,56 +72,90 @@ enum Reg {
     Command = 0x7e,
 }
 
+/// Accelerometer sampling rates.
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoPrimitive)]
 pub enum AccelConfigOdr {
+    /// 0.78 Hz
     Odr0p78 = 0x01,
+    /// 1.5 Hz
     Odr1p5 = 0x02,
+    /// 3.1 Hz
     Odr3p1 = 0x03,
+    /// 6.25 Hz
     Odr6p25 = 0x04,
+    /// 12.5 Hz
     Odr12p5 = 0x05,
+    /// 25 Hz
     Odr25 = 0x06,
+    /// 50 Hz
     Odr50 = 0x07,
+    /// 100 Hz
     Odr100 = 0x08,
+    /// 200 Hz
     Odr200 = 0x09,
+    /// 400 Hz
     Odr400 = 0x0a,
+    /// 800 Hz
     Odr800 = 0x0b,
+    /// 1.6 kHz
     Odr1k6 = 0x0c,
 }
 
+/// Accelerometer sample bandwidth and averaging.
+///
+/// Refer the the data sheet for further details.
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoPrimitive)]
 pub enum AccelConfigBandwidth {
+    /// Performance mode: OSR4, Low power mode: No averaging
     Osr4Avg1 = 0x00,
+    /// Performance mode: OSR2, Low power mode: Average 2 samples
     Osr2Avg2 = 0x10,
+    /// Performance mode: Normal, Low power mode: Average 4 samples
     NormAvg4 = 0x20,
+    /// Low power mode: Average 8 samples
     CicAvg8 = 0x30,
+    /// Low power mode: Average 16 samples
     ResAvg16 = 0x40,
+    /// Low power mode: Average 32 samples
     ResAvg32 = 0x50,
+    /// Low power mode: Average 64 samples
     ResAvg64 = 0x60,
+    /// Low power mode: Average 128 samples
     ResAvg128 = 0x70,
 }
 
+/// Accelerometer filter mode
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, IntoPrimitive)]
 pub enum AccelConfigPerfMode {
+    /// Averaging mode
     CicAvg = 0x00,
+    /// Continuous filter mode
     Continuous = 0x80,
 }
 
 /// Accelerometer acceleration vector range.
 ///
 /// Values measured outside this range will be clipped to
-/// the range.
+/// the range. Bear in mind that the signed range is quantized
+/// into 12 bits so that smaller ranges will have more
+/// resolution.
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoPrimitive)]
 pub enum AccelRange {
+    /// Max range of ±2 g
     Range2g = 0x00,
+    /// Max range of ±4 g
     Range4g = 0x01,
+    /// Max range of ±8 g
     Range8g = 0x02,
+    /// Max range of ±16 g
     Range16g = 0x03,
 }
 impl AccelRange {
+    /// Returns the range as a floating point in g.
     pub fn as_float(&self) -> f32 {
         match self {
             AccelRange::Range2g => 2.0,
@@ -161,7 +195,9 @@ pub enum HardwareInterruptStatus {
 /// Interrupt status structure.
 #[derive(Copy, Clone, Debug)]
 pub struct InterruptStatus {
+    /// Feature interrupt status
     pub feature: FeatureInterruptStatus,
+    /// Hardware interrupt status
     pub hardware: HardwareInterruptStatus,
 }
 
@@ -169,7 +205,9 @@ pub struct InterruptStatus {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoPrimitive)]
 pub enum InterruptLine {
+    /// Interrupt line 1
     Line1 = 0,
+    /// Interrupt line 2
     Line2 = 1,
 }
 
@@ -177,7 +215,9 @@ pub enum InterruptLine {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoPrimitive)]
 pub enum InterruptTriggerCondition {
+    /// Trigger when the level reaches a value
     Level = 0x00,
+    /// Trigger only on an edge
     Edge = 0x01,
 }
 
@@ -185,7 +225,9 @@ pub enum InterruptTriggerCondition {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoPrimitive)]
 pub enum InterruptLevel {
+    /// The interrupt line will be low when active and high otherwise
     ActiveLow = 0x00,
+    /// The interrupt line will be high when active and low otherwise
     ActiveHigh = 0x02,
 }
 
@@ -193,7 +235,10 @@ pub enum InterruptLevel {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoPrimitive)]
 pub enum InterruptOutputBehavior {
+    /// Push pull output, i.e. the pin drives the line voltage
     PushPull = 0x00,
+    /// Open drain output, i.e. the pin acts as a ground switch,
+    /// requiring that it be pulled up externally
     OpenDrain = 0x04,
 }
 
@@ -253,12 +298,18 @@ const DEFAULT_ADDRESS: u8 = 0x18;
 const READ_WRITE_LEN: usize = 0x08;
 const GRAVITY_EARTH: f32 = 9.80665;
 
+/// General accelerometer error.
+///
+/// The generic `E` is the error type of the I2C driver.
 #[derive(Clone, Copy, Debug)]
 pub enum Error<E> {
+    /// I2C bus error
     BusError(E),
-    I2cError,
+    /// Tried to set an invalid configuration
     ConfigError,
+    /// The chip is in an erroneous internal state
     BadInternal(u8),
+    /// An invalid argument was passed to a function
     BadArgument,
 }
 
@@ -272,19 +323,21 @@ impl<E> core::convert::From<E> for Error<E> {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, IntoPrimitive, FromPrimitive)]
 pub enum ChipId {
+    /// Unknown or invalid chip ID
     #[default]
     Unknown = 0x00,
+    /// The chip ID is correct
     Bma423 = 0x13,
 }
 
-// Uninitialized state.
+/// Uninitialized state.
 pub struct Uninitialized;
-// Normal full power state.
+/// Normal full power state.
 pub struct FullPower;
-// Power save state.
+/// Advanced power save state.
 pub struct PowerSave;
 
-// A general initialized state.
+/// A general initialized state.
 pub trait Initialized {}
 impl Initialized for FullPower {}
 impl Initialized for PowerSave {}
@@ -309,9 +362,13 @@ pub struct Bma423<I2C, S> {
 #[allow(dead_code)]
 #[derive(new, Copy, Clone, Debug)]
 pub struct Config {
+    /// The bandwidth or averaging mode
     pub bandwidth: AccelConfigBandwidth,
+    /// The range of measurable accelerations
     pub range: AccelRange,
+    /// Filter mode
     pub performance_mode: AccelConfigPerfMode,
+    /// Sampling rate
     pub sample_rate: AccelConfigOdr,
 }
 impl Default for Config {
@@ -513,6 +570,7 @@ impl<I2C: I2c> Bma423<I2C, FullPower> {
         Ok(feature_config)
     }*/
 
+    /// Transitions to advanced power save mode.
     pub fn power_save_mode(self) -> Result<Bma423<I2C, PowerSave>, Error<I2C::Error>> {
         let mut driver = Bma423 {
             address: self.address,
@@ -526,6 +584,7 @@ impl<I2C: I2c> Bma423<I2C, FullPower> {
     }
 }
 impl<I2C: I2c> Bma423<I2C, PowerSave> {
+    /// Transitions to full power mode.
     pub fn full_power_mode(self) -> Result<Bma423<I2C, FullPower>, Error<I2C::Error>> {
         let mut driver = Bma423 {
             address: self.address,
@@ -665,6 +724,11 @@ impl<I2C: I2c, S: Initialized> Bma423<I2C, S> {
     /// Reads and returns the general chip status byte.
     pub fn read_status(&mut self) -> Result<u8, Error<I2C::Error>> {
         self.read_register(Reg::Status)
+    }
+
+    /// Enables or disables FIFO self wake up.
+    pub fn set_fifo_self_wakeup(&mut self, enable: bool) -> Result<(), Error<I2C::Error>> {
+        self.set_power_config(PowerConfigurationFlag::FifoSelfWakeUp, enable)
     }
 
     /// Returns the normalized accelerations in g.


### PR DESCRIPTION
Hi, thanks for writing this driver, it's saved me a lot of time on a project I'm currently working on!

I needed to add some methods to configure the motion detection and tap detection features, to configure the interrupt pins, and map these features to the interrupts. I've tested all this and have them working well in my project. I also thought the crate could use some refactoring to make things a bit more efficient when configuring features, and to make the driver a little more robust in terms of tracking its state and not allowing bad things to happen. Please refer to the commit log and documentation for more details.

Also, I went ahead and added at least some documentation for every item and method, noting that bit mask items can evidently not be documented due to the macro expansion.

Let me know if you take issue with any of the design decisions I made, or have any ways to improve them.

I'm also interested in completing the implemented features down the road once I get my project to a certain point (the features I've already implemented are all I need for this project).

Thanks for considering this request and don't hesitate to provide any feedback on the changes.